### PR TITLE
Compass buttons and workflow

### DIFF
--- a/REFACTORING_NOTES.md
+++ b/REFACTORING_NOTES.md
@@ -1,0 +1,534 @@
+# Refaktorerings-notater: Aware App
+
+## Dato: November 2025
+
+## Oversikt
+Dette dokumentet beskriver områder som bør refaktoreres for bedre struktur, vedlikeholdbarhet og testbarhet.
+
+---
+
+## 1. Map Component - Props Overload
+
+### Problem
+`MapComponent` har **86+ props** som sendes ned gjennom flere lag:
+```
+page.tsx → awaremap.tsx → mapcomponent.tsx
+```
+
+### Konsekvenser
+- Vanskelig å vedlikeholde
+- Lett å glemme å sende props videre
+- TypeScript errors når nye props legges til
+- Uoversiktlig interface
+
+### Forslag til løsning
+**Grupper props i kontekst-objekter:**
+
+```typescript
+// Før:
+<MapComponent 
+  radius={radius}
+  angleRange={angleRange}
+  showMSRRetikkel={showMSRRetikkel}
+  msrRetikkelOpacity={msrRetikkelOpacity}
+  msrRetikkelStyle={msrRetikkelStyle}
+  msrRetikkelVerticalPosition={msrRetikkelVerticalPosition}
+  targetSize={targetSize}
+  shotSize={shotSize}
+  observationSize={observationSize}
+  targetLineColor={targetLineColor}
+  shotColor={shotColor}
+  targetColor={targetColor}
+  targetLineWeight={targetLineWeight}
+  compassSliceLength={compassSliceLength}
+  // ... +70 props mer
+/>
+
+// Etter:
+<MapComponent 
+  radius={radius}
+  reticleSettings={reticleSettings}
+  shootTrackSettings={shootTrackSettings}
+  compassSettings={compassSettings}
+  huntingAreaSettings={huntingAreaSettings}
+  // ... mye enklere!
+/>
+```
+
+**Eller bruk React Context:**
+```typescript
+<SettingsContext.Provider value={allSettings}>
+  <MapComponent />
+</SettingsContext.Provider>
+```
+
+---
+
+## 2. Kompass, GPS og Retikkel - Duplisert Pixel→Meter Logikk
+
+### Problem
+**Samme kode i 3 forskjellige steder:**
+- `CompassSlice` (mapcomponent.tsx)
+- `MSRRetikkel` (msr-retikkel.tsx)
+- Potensielt andre steder
+
+**Duplisert logikk:**
+```typescript
+// I CompassSlice:
+const metersPerPixel = 156543.03392 * Math.cos(center.lat * Math.PI / 180) / Math.pow(2, zoom);
+const meters = sliceLengthPixels * metersPerPixel;
+
+// I MSRRetikkel:
+const metersPerPixel = 156543.03392 * Math.cos(center.lat * Math.PI / 180) / Math.pow(2, zoom);
+const xDistanceMeters = Math.round(L_SIZE_PIXELS * metersPerPixel);
+```
+
+### Konsekvenser
+- Vanskelig å endre beregningen (må oppdateres 3 steder)
+- Risiko for inkonsistens
+- Ikke testbart isolert
+
+### Forslag til løsning
+**Lag en custom hook:**
+
+```typescript
+// hooks/useMapPixelConverter.ts
+export function useMapPixelConverter() {
+  const map = useMap();
+  const [metersPerPixel, setMetersPerPixel] = useState(1);
+
+  useEffect(() => {
+    if (!map) return;
+
+    const update = () => {
+      const zoom = map.getZoom();
+      const center = map.getCenter();
+      const mpp = 156543.03392 * Math.cos(center.lat * Math.PI / 180) / Math.pow(2, zoom);
+      setMetersPerPixel(mpp);
+    };
+
+    update();
+    map.on('zoomend', update);
+    map.on('moveend', update);
+
+    return () => {
+      map.off('zoomend', update);
+      map.off('moveend', update);
+    };
+  }, [map]);
+
+  return {
+    pixelsToMeters: (pixels: number) => pixels * metersPerPixel,
+    metersToPixels: (meters: number) => meters / metersPerPixel,
+    metersPerPixel,
+  };
+}
+
+// Bruk:
+const { pixelsToMeters } = useMapPixelConverter();
+const radiusMeters = pixelsToMeters(sliceLengthPixels);
+```
+
+**Eller en utility function:**
+```typescript
+// utils/mapCoordinates.ts
+export function getMetersPerPixel(zoom: number, latitude: number): number {
+  return 156543.03392 * Math.cos(latitude * Math.PI / 180) / Math.pow(2, zoom);
+}
+
+export function pixelsToMeters(pixels: number, zoom: number, latitude: number): number {
+  return pixels * getMetersPerPixel(zoom, latitude);
+}
+
+export function metersToLatLng(
+  centerLat: number,
+  centerLng: number,
+  distanceMeters: number,
+  bearingDegrees: number
+): [number, number] {
+  const rad = (bearingDegrees * Math.PI) / 180;
+  const lat = centerLat + (distanceMeters * Math.cos(rad)) / 111000;
+  const lng = centerLng + (distanceMeters * Math.sin(rad)) / (111000 * Math.cos(centerLat * Math.PI / 180));
+  return [lat, lng];
+}
+```
+
+---
+
+## 3. Compass Implementation - Spredt State
+
+### Problem
+**Kompass-state er spredt over:**
+- `useCompass` hook (sensor handling)
+- `MapComponent` (compassMode state)
+- `CompassSlice` (rendering)
+- `MapRotator` (map rotation)
+- Settings menu (lengde slider)
+- page.tsx (compassSliceLength state)
+
+### Konsekvenser
+- Vanskelig å se helheten
+- State er i forskjellige komponenter
+- Logikk spredt mange steder
+
+### Forslag til løsning
+**Lag en dedikert `CompassManager` komponent:**
+
+```typescript
+// components/CompassManager.tsx
+export function CompassManager() {
+  const [mode, setMode] = useState<'off' | 'arrow' | 'map'>('off');
+  const [sliceLength, setSliceLength] = useState(30);
+  const compass = useCompass({ isEnabled: mode !== 'off' });
+
+  return (
+    <>
+      <CompassSlice mode={mode} heading={compass.currentHeading} length={sliceLength} />
+      <MapRotator isEnabled={mode === 'map'} heading={compass.currentHeading} />
+      <CompassButton mode={mode} onModeChange={setMode} />
+    </>
+  );
+}
+```
+
+**Eller bruk en custom hook med all logikk:**
+```typescript
+// hooks/useCompassState.ts
+export function useCompassState() {
+  const [mode, setMode] = useState<'off' | 'arrow' | 'map'>('off');
+  const [sliceLength, setSliceLength] = useState(30);
+  const compass = useCompass({ isEnabled: mode !== 'off' });
+
+  const cycleMode = useCallback(async () => {
+    if (mode === 'off') {
+      await compass.startCompass();
+      setMode('arrow');
+    } else if (mode === 'arrow') {
+      setMode('map');
+    } else {
+      compass.stopCompass();
+      setMode('off');
+    }
+  }, [mode, compass]);
+
+  return {
+    mode,
+    heading: compass.currentHeading,
+    sliceLength,
+    setSliceLength,
+    cycleMode,
+    isActive: compass.isActive,
+  };
+}
+```
+
+---
+
+## 4. Settings Management - LocalStorage Håndtering
+
+### Problem
+**Settings lastes og lagres på 10+ steder:**
+- Hver setting har sin egen `useEffect`
+- Duplisert `localStorage.getItem` / `setItem` kode
+- Ingen sentralisert settings-håndtering
+- "Save as default" må manuelt liste opp alle settings
+
+### Forslag til løsning
+**Lag en Settings Service:**
+
+```typescript
+// services/settingsService.ts
+interface AppSettings {
+  compass: {
+    sliceLength: number;
+  };
+  reticle: {
+    show: boolean;
+    opacity: number;
+    style: 'msr' | 'ivar';
+    verticalPosition: number;
+  };
+  shootTrack: {
+    targetSize: number;
+    shotSize: number;
+    observationSize: number;
+    targetLineColor: string;
+    shotColor: string;
+    targetColor: string;
+    targetLineWeight: number;
+  };
+  // etc...
+}
+
+const DEFAULT_SETTINGS: AppSettings = {
+  compass: { sliceLength: 30 },
+  reticle: { show: false, opacity: 80, style: 'ivar', verticalPosition: 50 },
+  shootTrack: { targetSize: 15, shotSize: 5, /* ... */ },
+};
+
+export class SettingsService {
+  private static KEY = 'aware_app_settings';
+
+  static load(): AppSettings {
+    const stored = localStorage.getItem(this.KEY);
+    return stored ? { ...DEFAULT_SETTINGS, ...JSON.parse(stored) } : DEFAULT_SETTINGS;
+  }
+
+  static save(settings: AppSettings): void {
+    localStorage.setItem(this.KEY, JSON.stringify(settings));
+  }
+
+  static reset(): void {
+    localStorage.removeItem(this.KEY);
+  }
+}
+
+// Bruk med Context:
+const SettingsContext = createContext<AppSettings>(DEFAULT_SETTINGS);
+
+export function SettingsProvider({ children }) {
+  const [settings, setSettings] = useState<AppSettings>(SettingsService.load);
+
+  const updateSettings = (updates: Partial<AppSettings>) => {
+    const newSettings = { ...settings, ...updates };
+    setSettings(newSettings);
+    SettingsService.save(newSettings);
+  };
+
+  return (
+    <SettingsContext.Provider value={{ settings, updateSettings }}>
+      {children}
+    </SettingsContext.Provider>
+  );
+}
+```
+
+---
+
+## 5. Mode-basert UI - Switch-statement Hell
+
+### Problem
+**Mange steder med mode-basert conditional rendering:**
+```typescript
+{mode === 'aware' && <AwareButtons />}
+{mode === 'track' && <TrackButtons />}
+{mode === 'søk' && <SearchButtons />}
+
+// 20+ lignende blokker i samme fil
+```
+
+### Forslag til løsning
+**Component composition pattern:**
+
+```typescript
+// components/ModeButtons.tsx
+const MODE_COMPONENTS = {
+  aware: AwareModeButtons,
+  track: TrackModeButtons,
+  søk: SearchModeButtons,
+} as const;
+
+export function ModeButtons({ mode }: { mode: Mode }) {
+  const Component = MODE_COMPONENTS[mode];
+  return <Component />;
+}
+
+// Eller med strategy pattern:
+interface ModeStrategy {
+  renderButtons(): JSX.Element;
+  renderQuickFilters(): JSX.Element;
+  renderMapOverlay(): JSX.Element;
+}
+
+class AwareModeStrategy implements ModeStrategy {
+  renderButtons() { return <AwareModeButtons />; }
+  renderQuickFilters() { return <AwareModeQuickFilters />; }
+  renderMapOverlay() { return <AwareModeOverlay />; }
+}
+
+// etc...
+```
+
+---
+
+## 6. Event Handlers - Callback Props Overload
+
+### Problem
+**50+ event handler props:**
+```typescript
+onRadiusChange
+onAngleRangeChange
+onShowMarkersChange
+onShowMSRRetikkelChange
+onMSRRetikkelOpacityChange
+onMSRRetikkelStyleChange
+onMSRRetikkelVerticalPositionChange
+onTargetSizeChange
+onShotSizeChange
+// ... +40 flere
+```
+
+### Forslag til løsning
+**Reducer pattern eller event bus:**
+
+```typescript
+// Med useReducer:
+type SettingsAction =
+  | { type: 'SET_RADIUS'; value: number }
+  | { type: 'SET_ANGLE_RANGE'; value: number }
+  | { type: 'SET_RETICLE_OPACITY'; value: number }
+  | { type: 'SET_RETICLE_STYLE'; value: 'msr' | 'ivar' }
+  // ...
+
+const [settings, dispatch] = useReducer(settingsReducer, initialSettings);
+
+// Bruk:
+dispatch({ type: 'SET_RADIUS', value: 3000 });
+
+// Eller med event emitter:
+settingsEmitter.emit('change', { radius: 3000 });
+```
+
+---
+
+## 7. Data Fetching - Spredt Supabase Logikk
+
+### Problem
+**Supabase queries spredt over:**
+- `MapComponent` (posts, tracks, finds, observations)
+- `page.tsx` (hunting areas)
+- Inline i komponenter
+- Duplisert error handling
+
+### Forslag til løsning
+**Data access layer:**
+
+```typescript
+// services/dataService.ts
+export class DataService {
+  constructor(private supabase: SupabaseClient) {}
+
+  async getPosts(teamId: string) {
+    const { data, error } = await this.supabase
+      .from('posts')
+      .select('*')
+      .eq('team_id', teamId);
+    
+    if (error) throw new DataServiceError('Failed to fetch posts', error);
+    return data;
+  }
+
+  async getTracks(teamId: string) { /* ... */ }
+  async getHuntingAreas(teamId: string) { /* ... */ }
+  // etc...
+}
+
+// Med React Query for caching:
+export function usePosts(teamId: string) {
+  return useQuery(['posts', teamId], () => dataService.getPosts(teamId));
+}
+```
+
+---
+
+## Prioritering
+
+### Høy prioritet (gjør nå)
+1. **Settings Context** - Reduser props hell
+2. **Pixel→Meter utility** - Fjern duplikasjon
+
+### Medium prioritet (snart)
+3. **Compass Manager** - Samle kompass-logikk
+4. **Mode Strategy** - Rydd opp i mode-logic
+
+### Lav prioritet (senere)
+5. **Data Access Layer** - Når flere features kommer
+6. **Event Bus** - Hvis callback-hell blir verre
+
+---
+
+## Testing-vennlighet
+
+### Nåværende problemer
+- Vanskelig å teste isolert
+- Mye avhengighet på Leaflet map
+- Ingen mocking av localStorage
+- Komponent-logikk blandet med rendering
+
+### Forslag
+```typescript
+// Separer business logic:
+export function calculateCompassSlicePoints(
+  centerLat: number,
+  centerLng: number,
+  radiusMeters: number,
+  headingDegrees: number,
+  angleRange: number
+): [number, number][] {
+  // Ren funksjon - lett å teste!
+}
+
+// Test:
+test('calculateCompassSlicePoints creates correct arc', () => {
+  const points = calculateCompassSlicePoints(60, 10, 100, 0, 1);
+  expect(points).toHaveLength(3); // center + arc + center
+  expect(points[0]).toEqual([60, 10]); // starts at center
+});
+```
+
+---
+
+## Konklusjon
+
+**Hovedproblemet:** Komponenter gjør for mye, og state/logikk er spredt.
+
+**Løsning:** 
+1. Separer business logic fra rendering
+2. Bruk contexts for å dele state
+3. Lag reusable utilities
+4. Component composition over conditional rendering
+
+**Neste steg:**
+- Start med Settings Context (biggest win)
+- Refactor pixel→meter logikk til utility
+- Gradvis splitt store komponenter
+
+---
+
+## Eksempel på "Etter Refaktorering"
+
+```typescript
+// page.tsx - MYE enklere!
+export default function Home() {
+  const { settings, updateSettings } = useSettings();
+  const { mode, setMode } = useMode();
+  
+  return (
+    <SettingsProvider value={settings}>
+      <ModeProvider value={mode}>
+        <AwareMap />
+        <ModeButtons mode={mode} onModeChange={setMode} />
+        <SettingsMenu />
+      </ModeProvider>
+    </SettingsProvider>
+  );
+}
+
+// mapcomponent.tsx - Fokusert på rendering!
+export default function MapComponent() {
+  const settings = useSettings();
+  const { mode } = useMode();
+  const compass = useCompassState();
+  
+  return (
+    <MapContainer>
+      <ModeStrategy mode={mode} />
+      <CompassManager state={compass} />
+      <MSRRetikkel config={settings.reticle} />
+    </MapContainer>
+  );
+}
+```
+
+**Resultatet:** Kode som er lett å forstå, teste og vedlikeholde! 🎉
+

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -443,10 +443,20 @@ export default function Home() {
         return (
           <div className="w-full h-screen">
 
-        {/* Admin hamburger-knapp og Lock-knapp oppe til høyre */}
-        <div className="fixed top-4 right-4 z-[2001] flex gap-2">
-          {/* Lock-knapp - kun synlig når kompass er på */}
-          {compassMode === 'on' && (
+        {/* Admin hamburger-knapp oppe til høyre */}
+        <div className="fixed top-4 right-4 z-[2001]">
+          <button
+            onClick={() => setIsAdminExpanded(!isAdminExpanded)}
+            className="w-10 h-10 bg-gray-800 hover:bg-gray-700 text-white rounded-lg shadow-lg flex items-center justify-center transition-colors"
+            title="Admin Panel"
+          >
+            <span className="text-lg">☰</span>
+          </button>
+        </div>
+        
+        {/* Lock-knapp - under admin-knappen, kun synlig når kompass er på */}
+        {compassMode === 'on' && (
+          <div className="fixed top-16 right-4 z-[2001]">
             <button
               onClick={() => setIsCompassLocked(!isCompassLocked)}
               className={`w-10 h-10 rounded-lg shadow-lg flex items-center justify-center transition-colors ${
@@ -458,16 +468,8 @@ export default function Home() {
             >
               <span className="text-lg">⬆️</span>
             </button>
-          )}
-          
-          <button
-            onClick={() => setIsAdminExpanded(!isAdminExpanded)}
-            className="w-10 h-10 bg-gray-800 hover:bg-gray-700 text-white rounded-lg shadow-lg flex items-center justify-center transition-colors"
-            title="Admin Panel"
-          >
-            <span className="text-lg">☰</span>
-          </button>
-        </div>
+          </div>
+        )}
         
         {/* Mode-toggle og menyknapper alltid synlig, fixed og midtjustert, også på mobil */}
       <div className="fixed top-0 left-1/2 -translate-x-1/2 z-[2001] flex justify-center items-center w-full max-w-xs px-2 py-2 gap-2">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -89,6 +89,9 @@ export default function Home() {
   const [msrRetikkelOpacity, setMSRRetikkelOpacity] = useState(80);
   const [msrRetikkelStyle, setMSRRetikkelStyle] = useState<'msr' | 'ivar'>('ivar');
   const [msrRetikkelVerticalPosition, setMSRRetikkelVerticalPosition] = useState(50);
+  
+  // State for Compass
+  const [compassSliceLength, setCompassSliceLength] = useState(30); // % of screen height
   const [categoryConfigs, setCategoryConfigs] = useState<Record<keyof CategoryFilter, CategoryConfig>>({
     city: {
       color: '#1e40af', // Dark blue
@@ -558,6 +561,8 @@ export default function Home() {
             onHuntingBoundaryColorChange={setHuntingBoundaryColor}
             onHuntingBoundaryWeightChange={setHuntingBoundaryWeight}
             onHuntingBoundaryOpacityChange={setHuntingBoundaryOpacity}
+            compassSliceLength={compassSliceLength}
+            onCompassSliceLengthChange={setCompassSliceLength}
           />
         </div>
       )}
@@ -644,6 +649,7 @@ export default function Home() {
         onRefreshHuntingAreas={loadHuntingAreas}
         onRegisterSync={(fn) => { syncCallbackRef.current = fn; }}
         activeTeam={authState.activeTeam?.id || null}
+        compassSliceLength={compassSliceLength}
       />
 
       {/* Admin Menu */}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useRef, useEffect, useState } from 'react';
+import { useRef, useEffect, useState, useCallback } from 'react';
 import AwareMap from '@/components/awaremap';
 import SettingsMenu, { HuntingArea } from '@/components/settingsmenu';
 import FilterMenu from '@/components/filtermenu';
@@ -387,6 +387,15 @@ export default function Home() {
     window.location.reload();
   };
 
+  // Sync callback registered by MapComponent
+  const syncCallbackRef = useRef<(() => void) | null>(null);
+  
+  const handleSyncFromFilter = () => {
+    if (syncCallbackRef.current) {
+      syncCallbackRef.current();
+    }
+  };
+
   // Funksjoner for å navigere mellom treffpunkter i søk-modus
   const handlePreviousTarget = () => {
     setSelectedTargetIndex(prev => {
@@ -577,6 +586,7 @@ export default function Home() {
           onShowTracksChange={setShowTracks}
           showHuntingBoundary={showHuntingBoundary}
           onShowHuntingBoundaryChange={setShowHuntingBoundary}
+          onSync={handleSyncFromFilter}
         />
         </div>
       )}
@@ -632,6 +642,7 @@ export default function Home() {
         onHuntingAreaDefined={handleHuntingAreaDefined}
         onCancelHuntingAreaDefinition={handleCancelHuntingAreaDefinition}
         onRefreshHuntingAreas={loadHuntingAreas}
+        onRegisterSync={(fn) => { syncCallbackRef.current = fn; }}
         activeTeam={authState.activeTeam?.id || null}
       />
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -92,6 +92,8 @@ export default function Home() {
   
   // State for Compass
   const [compassSliceLength, setCompassSliceLength] = useState(30); // % of screen height
+  const [compassMode, setCompassMode] = useState<'off' | 'on'>('off');
+  const [isCompassLocked, setIsCompassLocked] = useState(false);
   const [categoryConfigs, setCategoryConfigs] = useState<Record<keyof CategoryFilter, CategoryConfig>>({
     city: {
       color: '#1e40af', // Dark blue
@@ -441,8 +443,23 @@ export default function Home() {
         return (
           <div className="w-full h-screen">
 
-        {/* Admin hamburger-knapp oppe til høyre */}
-        <div className="fixed top-4 right-4 z-[2001]">
+        {/* Admin hamburger-knapp og Lock-knapp oppe til høyre */}
+        <div className="fixed top-4 right-4 z-[2001] flex gap-2">
+          {/* Lock-knapp - kun synlig når kompass er på */}
+          {compassMode === 'on' && (
+            <button
+              onClick={() => setIsCompassLocked(!isCompassLocked)}
+              className={`w-10 h-10 rounded-lg shadow-lg flex items-center justify-center transition-colors ${
+                isCompassLocked
+                  ? 'bg-blue-600 hover:bg-blue-700 text-white'
+                  : 'bg-gray-200 hover:bg-gray-300 text-gray-700'
+              }`}
+              title={isCompassLocked ? 'Låst: Kart roterer' : 'Ulåst: Pil roterer'}
+            >
+              <span className="text-lg">⬆️</span>
+            </button>
+          )}
+          
           <button
             onClick={() => setIsAdminExpanded(!isAdminExpanded)}
             className="w-10 h-10 bg-gray-800 hover:bg-gray-700 text-white rounded-lg shadow-lg flex items-center justify-center transition-colors"
@@ -650,6 +667,10 @@ export default function Home() {
         onRegisterSync={(fn) => { syncCallbackRef.current = fn; }}
         activeTeam={authState.activeTeam?.id || null}
         compassSliceLength={compassSliceLength}
+        compassMode={compassMode}
+        isCompassLocked={isCompassLocked}
+        onCompassModeChange={setCompassMode}
+        onCompassLockedChange={setIsCompassLocked}
       />
 
       {/* Admin Menu */}

--- a/src/components/awaremap.tsx
+++ b/src/components/awaremap.tsx
@@ -88,6 +88,7 @@ interface AwareMapProps {
   onHuntingAreaDefined?: (area: HuntingArea) => void;
   onCancelHuntingAreaDefinition?: () => void;
   onRefreshHuntingAreas?: () => void;
+  onRegisterSync?: (syncFn: () => void) => void;
 }
 
 export default function AwareMap({
@@ -142,6 +143,7 @@ export default function AwareMap({
   onHuntingAreaDefined,
   onCancelHuntingAreaDefinition,
   onRefreshHuntingAreas,
+  onRegisterSync,
 }: AwareMapProps) {
   const [isClient, setIsClient] = useState(false);
   const [hasError, setHasError] = useState(false);
@@ -229,6 +231,7 @@ export default function AwareMap({
         onHuntingAreaDefined={onHuntingAreaDefined}
         onCancelHuntingAreaDefinition={onCancelHuntingAreaDefinition}
         onRefreshHuntingAreas={onRefreshHuntingAreas}
+        onRegisterSync={onRegisterSync}
       />
     </div>
   );

--- a/src/components/awaremap.tsx
+++ b/src/components/awaremap.tsx
@@ -89,6 +89,7 @@ interface AwareMapProps {
   onCancelHuntingAreaDefinition?: () => void;
   onRefreshHuntingAreas?: () => void;
   onRegisterSync?: (syncFn: () => void) => void;
+  compassSliceLength?: number;
 }
 
 export default function AwareMap({
@@ -144,6 +145,7 @@ export default function AwareMap({
   onCancelHuntingAreaDefinition,
   onRefreshHuntingAreas,
   onRegisterSync,
+  compassSliceLength,
 }: AwareMapProps) {
   const [isClient, setIsClient] = useState(false);
   const [hasError, setHasError] = useState(false);
@@ -232,6 +234,7 @@ export default function AwareMap({
         onCancelHuntingAreaDefinition={onCancelHuntingAreaDefinition}
         onRefreshHuntingAreas={onRefreshHuntingAreas}
         onRegisterSync={onRegisterSync}
+        compassSliceLength={compassSliceLength}
       />
     </div>
   );

--- a/src/components/awaremap.tsx
+++ b/src/components/awaremap.tsx
@@ -90,6 +90,10 @@ interface AwareMapProps {
   onRefreshHuntingAreas?: () => void;
   onRegisterSync?: (syncFn: () => void) => void;
   compassSliceLength?: number;
+  compassMode?: 'off' | 'on';
+  isCompassLocked?: boolean;
+  onCompassModeChange?: (mode: 'off' | 'on') => void;
+  onCompassLockedChange?: (locked: boolean) => void;
 }
 
 export default function AwareMap({
@@ -146,6 +150,10 @@ export default function AwareMap({
   onRefreshHuntingAreas,
   onRegisterSync,
   compassSliceLength,
+  compassMode,
+  isCompassLocked,
+  onCompassModeChange,
+  onCompassLockedChange,
 }: AwareMapProps) {
   const [isClient, setIsClient] = useState(false);
   const [hasError, setHasError] = useState(false);
@@ -235,6 +243,10 @@ export default function AwareMap({
         onRefreshHuntingAreas={onRefreshHuntingAreas}
         onRegisterSync={onRegisterSync}
         compassSliceLength={compassSliceLength}
+        compassMode={compassMode}
+        isCompassLocked={isCompassLocked}
+        onCompassModeChange={onCompassModeChange}
+        onCompassLockedChange={onCompassLockedChange}
       />
     </div>
   );

--- a/src/components/filtermenu.tsx
+++ b/src/components/filtermenu.tsx
@@ -50,7 +50,7 @@ const categoryLabels: Record<keyof CategoryFilter, string> = {
   isolated_dwelling: 'Enkeltbolig',
 };
 
-export default function FilterMenu({ categoryFilters, onCategoryChange, radius, onRadiusChange, showMarkers, onShowMarkersChange, orientationMode, onOrientationModeChange, categoryConfigs, showOnlyLastShot, onShowOnlyLastShotChange, mode, showAllTracksAndFinds, onShowAllTracksAndFindsChange, showObservations, onShowObservationsChange, showShots, onShowShotsChange, showTracks, onShowTracksChange, showHuntingBoundary, onShowHuntingBoundaryChange, onSync }: FilterMenuProps) {
+export default function FilterMenu({ categoryFilters, onCategoryChange, radius, onRadiusChange, showMarkers, onShowMarkersChange, orientationMode, onOrientationModeChange, categoryConfigs, showOnlyLastShot, onShowOnlyLastShotChange, mode, showAllTracksAndFinds, onShowAllTracksAndFindsChange, showObservations, onShowObservationsChange, showShots, onShowShotsChange, showTracks, onShowTracksChange, showHuntingBoundary, onShowHuntingBoundaryChange }: FilterMenuProps) {
   return (
     <div className="bg-white rounded-lg shadow-lg p-4 min-w-[220px] max-w-xs">
       <div className="flex items-center justify-between mb-2">

--- a/src/components/filtermenu.tsx
+++ b/src/components/filtermenu.tsx
@@ -38,6 +38,7 @@ interface FilterMenuProps {
   onShowTracksChange?: (v: boolean) => void;
   showHuntingBoundary?: boolean;
   onShowHuntingBoundaryChange?: (v: boolean) => void;
+  onSync?: () => void;
 }
 
 const categoryLabels: Record<keyof CategoryFilter, string> = {
@@ -49,7 +50,7 @@ const categoryLabels: Record<keyof CategoryFilter, string> = {
   isolated_dwelling: 'Enkeltbolig',
 };
 
-export default function FilterMenu({ categoryFilters, onCategoryChange, radius, onRadiusChange, showMarkers, onShowMarkersChange, orientationMode, onOrientationModeChange, categoryConfigs, showOnlyLastShot, onShowOnlyLastShotChange, mode, showAllTracksAndFinds, onShowAllTracksAndFindsChange, showObservations, onShowObservationsChange, showShots, onShowShotsChange, showTracks, onShowTracksChange, showHuntingBoundary, onShowHuntingBoundaryChange }: FilterMenuProps) {
+export default function FilterMenu({ categoryFilters, onCategoryChange, radius, onRadiusChange, showMarkers, onShowMarkersChange, orientationMode, onOrientationModeChange, categoryConfigs, showOnlyLastShot, onShowOnlyLastShotChange, mode, showAllTracksAndFinds, onShowAllTracksAndFindsChange, showObservations, onShowObservationsChange, showShots, onShowShotsChange, showTracks, onShowTracksChange, showHuntingBoundary, onShowHuntingBoundaryChange, onSync }: FilterMenuProps) {
   return (
     <div className="bg-white rounded-lg shadow-lg p-4 min-w-[220px] max-w-xs">
       <div className="flex items-center justify-between mb-2">
@@ -309,6 +310,19 @@ export default function FilterMenu({ categoryFilters, onCategoryChange, radius, 
               Jaktgrenser
             </span>
           </label>
+        </div>
+      )}
+      
+      {/* Sync button i track-modus */}
+      {mode === 'søk' && onSync && (
+        <div className="mt-4 pt-3 border-t border-gray-200">
+          <button
+            onClick={onSync}
+            className="w-full bg-blue-600 hover:bg-blue-700 text-white font-semibold py-2 px-4 rounded shadow-lg text-sm flex items-center justify-center gap-2"
+          >
+            <span>🔄</span>
+            <span>Synkroniser</span>
+          </button>
         </div>
       )}
     </div>

--- a/src/components/filtermenu.tsx
+++ b/src/components/filtermenu.tsx
@@ -50,7 +50,7 @@ const categoryLabels: Record<keyof CategoryFilter, string> = {
   isolated_dwelling: 'Enkeltbolig',
 };
 
-export default function FilterMenu({ categoryFilters, onCategoryChange, radius, onRadiusChange, showMarkers, onShowMarkersChange, orientationMode, onOrientationModeChange, categoryConfigs, showOnlyLastShot, onShowOnlyLastShotChange, mode, showAllTracksAndFinds, onShowAllTracksAndFindsChange, showObservations, onShowObservationsChange, showShots, onShowShotsChange, showTracks, onShowTracksChange, showHuntingBoundary, onShowHuntingBoundaryChange }: FilterMenuProps) {
+export default function FilterMenu({ categoryFilters, onCategoryChange, radius, onRadiusChange, showMarkers, onShowMarkersChange, orientationMode, onOrientationModeChange, categoryConfigs, showOnlyLastShot, onShowOnlyLastShotChange, mode, showAllTracksAndFinds, onShowAllTracksAndFindsChange, showObservations, onShowObservationsChange, showShots, onShowShotsChange, showTracks, onShowTracksChange, showHuntingBoundary, onShowHuntingBoundaryChange, onSync }: FilterMenuProps) {
   return (
     <div className="bg-white rounded-lg shadow-lg p-4 min-w-[220px] max-w-xs">
       <div className="flex items-center justify-between mb-2">

--- a/src/components/mapcomponent.tsx
+++ b/src/components/mapcomponent.tsx
@@ -3441,29 +3441,6 @@ export default function MapComponent({
             </>
           )}
 
-          {/* Layer-knapp */}
-          <button
-            className="w-12 h-12 rounded-full shadow-lg transition-colors flex items-center justify-center bg-white/90 border border-gray-300 hover:bg-gray-100"
-            onClick={() => setLayerIdx((layerIdx + 1) % LAYER_CONFIGS.length)}
-            title={`Bytt kartlag (${LAYER_CONFIGS[layerIdx].name})`}
-            style={{ zIndex: 2002 }}
-          >
-            <span className="w-7 h-7 flex items-center justify-center"><LayersIcon /></span>
-          </button>
-          
-          {/* Live-posisjon-knapp */}
-          <button
-            onClick={() => onLiveModeChange?.(!isLiveMode)}
-            className={`w-12 h-12 rounded-full shadow-lg transition-colors flex items-center justify-center ${
-              isLiveMode 
-                ? 'bg-green-600 hover:bg-green-700 text-white' 
-                : 'bg-gray-600 hover:bg-gray-700 text-white'
-            }`}
-            title={isLiveMode ? 'Live GPS ON' : 'Live GPS'}
-          >
-            🛰️
-          </button>
-          
           {/* Kompass-knapp - alltid synlig */}
           {!compass.isActive ? (
             <button
@@ -3491,6 +3468,29 @@ export default function MapComponent({
               🧭
             </button>
           )}
+          
+          {/* Live-posisjon-knapp */}
+          <button
+            onClick={() => onLiveModeChange?.(!isLiveMode)}
+            className={`w-12 h-12 rounded-full shadow-lg transition-colors flex items-center justify-center ${
+              isLiveMode 
+                ? 'bg-green-600 hover:bg-green-700 text-white' 
+                : 'bg-gray-600 hover:bg-gray-700 text-white'
+            }`}
+            title={isLiveMode ? 'Live GPS ON' : 'Live GPS'}
+          >
+            🛰️
+          </button>
+          
+          {/* Layer-knapp */}
+          <button
+            className="w-12 h-12 rounded-full shadow-lg transition-colors flex items-center justify-center bg-white/90 border border-gray-300 hover:bg-gray-100"
+            onClick={() => setLayerIdx((layerIdx + 1) % LAYER_CONFIGS.length)}
+            title={`Bytt kartlag (${LAYER_CONFIGS[layerIdx].name})`}
+            style={{ zIndex: 2002 }}
+          >
+            <span className="w-7 h-7 flex items-center justify-center"><LayersIcon /></span>
+          </button>
           
           {/* Lock map on GPS-knapp - kun når GPS er aktiv */}
           {isLiveMode && (

--- a/src/components/mapcomponent.tsx
+++ b/src/components/mapcomponent.tsx
@@ -3597,36 +3597,8 @@ export default function MapComponent({
             </>
           )}
 
-          {/* Layer-knapp */}
-          <button
-            className="w-12 h-12 rounded-full shadow-lg transition-colors flex items-center justify-center bg-white/90 border border-gray-300 hover:bg-gray-100"
-            onClick={() => setLayerIdx((layerIdx + 1) % LAYER_CONFIGS.length)}
-            title={`Bytt kartlag (${LAYER_CONFIGS[layerIdx].name})`}
-            style={{ zIndex: 2002 }}
-          >
-            <span className="w-7 h-7 flex items-center justify-center"><LayersIcon /></span>
-          </button>
-          
-          {/* Live-posisjon-knapp */}
-          <button
-            onClick={() => {
-              const newLiveMode = !isLiveMode;
-              onLiveModeChange?.(newLiveMode);
-              // Auto-lock map when GPS is enabled, unlock when disabled
-              setIsMapLocked(newLiveMode);
-            }}
-            className={`w-12 h-12 rounded-full shadow-lg transition-colors flex items-center justify-center ${
-              isLiveMode 
-                ? 'bg-green-600 hover:bg-green-700 text-white' 
-                : 'bg-gray-600 hover:bg-gray-700 text-white'
-            }`}
-            title={isLiveMode ? 'Live GPS ON (locked)' : 'Live GPS'}
-          >
-            🛰️
-          </button>
-          
           {/* Kompass-knapp - toggle on/off */}
-          <button
+            <button
             onClick={async () => {
               if (compassMode === 'off') {
                 // Turn on compass
@@ -3650,8 +3622,36 @@ export default function MapComponent({
                 : 'bg-green-600 hover:bg-green-700 text-white'
             }`}
             title={compassMode === 'off' ? 'Start kompass' : 'Stopp kompass'}
+            >
+              🧭
+            </button>
+          
+          {/* Live-posisjon-knapp */}
+            <button
+              onClick={() => {
+              const newLiveMode = !isLiveMode;
+              onLiveModeChange?.(newLiveMode);
+              // Auto-lock map when GPS is enabled, unlock when disabled
+              setIsMapLocked(newLiveMode);
+            }}
+            className={`w-12 h-12 rounded-full shadow-lg transition-colors flex items-center justify-center ${
+              isLiveMode 
+                ? 'bg-green-600 hover:bg-green-700 text-white' 
+                : 'bg-gray-600 hover:bg-gray-700 text-white'
+            }`}
+            title={isLiveMode ? 'Live GPS ON (locked)' : 'Live GPS'}
           >
-            🧭
+            🛰️
+            </button>
+          
+          {/* Layer-knapp */}
+          <button
+            className="w-12 h-12 rounded-full shadow-lg transition-colors flex items-center justify-center bg-white/90 border border-gray-300 hover:bg-gray-100"
+            onClick={() => setLayerIdx((layerIdx + 1) % LAYER_CONFIGS.length)}
+            title={`Bytt kartlag (${LAYER_CONFIGS[layerIdx].name})`}
+            style={{ zIndex: 2002 }}
+          >
+            <span className="w-7 h-7 flex items-center justify-center"><LayersIcon /></span>
           </button>
         </div>
 

--- a/src/components/mapcomponent.tsx
+++ b/src/components/mapcomponent.tsx
@@ -424,7 +424,7 @@ function CompassSlice({
   centerLat,
   centerLng,
   radius = 100, // meters
-  angleRange = 15, // ± degrees (total 30 degree slice)
+  angleRange = 1, // ± degrees (total 2 degree slice - narrow arrow)
 }: { 
   heading: number | null; 
   mode: 'off' | 'arrow' | 'map';
@@ -2575,7 +2575,7 @@ export default function MapComponent({
             centerLat={currentPosition.lat}
             centerLng={currentPosition.lng}
             radius={100}
-            angleRange={15}
+            angleRange={1}
           />
         )}
 

--- a/src/components/mapcomponent.tsx
+++ b/src/components/mapcomponent.tsx
@@ -3298,8 +3298,8 @@ export default function MapComponent({
                     : `${(totalDistance / 1000).toFixed(2)}km`)
                 : '0m'
               }
-            </span>
-            </div>
+                     </span>
+             </div>
 
           {/* Måle-knapp - avlang */}
           <button
@@ -3314,14 +3314,14 @@ export default function MapComponent({
           >
             📏
           </button>
-          </div>
-        )}
-
+        </div>
+      )}
+      
                         {/* Start/Stopp spor knapp kun i søk-modus */}
         {mode === 'søk' && (
           <div className="fixed bottom-4 inset-x-0 z-[2001] flex flex-wrap justify-center items-center gap-2 px-2 -ml-[15px]" style={{ pointerEvents: 'none' }}>
                     {/* Obs-knapp */}
-          <button
+            <button
                       onClick={toggleObservationMode}
                       className="flex-1 min-w-[60px] max-w-[55px] w-auto h-12 rounded-full shadow-lg font-semibold text-[0.75rem] transition-colors border flex items-center justify-center px-[0.375em] py-[0.375em] bg-orange-600 hover:bg-orange-700 text-white border-orange-700"
                       title="Legg til observasjon"
@@ -3422,13 +3422,13 @@ export default function MapComponent({
               )}
               
               {/* Pil venstre - forrige treffpunkt */}
-              <button
+          <button
                 onClick={onPreviousTarget}
                 className="w-12 h-12 rounded-full shadow-lg transition-colors flex items-center justify-center bg-blue-600 hover:bg-blue-700 text-white"
                 title="Forrige treffpunkt"
               >
                 ←
-              </button>
+          </button>
               
               {/* Pil høyre - neste treffpunkt */}
               <button
@@ -3441,6 +3441,16 @@ export default function MapComponent({
             </>
           )}
 
+          {/* Layer-knapp */}
+          <button
+            className="w-12 h-12 rounded-full shadow-lg transition-colors flex items-center justify-center bg-white/90 border border-gray-300 hover:bg-gray-100"
+            onClick={() => setLayerIdx((layerIdx + 1) % LAYER_CONFIGS.length)}
+            title={`Bytt kartlag (${LAYER_CONFIGS[layerIdx].name})`}
+            style={{ zIndex: 2002 }}
+          >
+            <span className="w-7 h-7 flex items-center justify-center"><LayersIcon /></span>
+          </button>
+          
           {/* Live-posisjon-knapp */}
           <button
             onClick={() => onLiveModeChange?.(!isLiveMode)}
@@ -3454,32 +3464,8 @@ export default function MapComponent({
             🛰️
           </button>
           
-          {/* Layer-knapp */}
-          <button
-            className="w-12 h-12 rounded-full shadow-lg transition-colors flex items-center justify-center bg-white/90 border border-gray-300 hover:bg-gray-100"
-            onClick={() => setLayerIdx((layerIdx + 1) % LAYER_CONFIGS.length)}
-            title={`Bytt kartlag (${LAYER_CONFIGS[layerIdx].name})`}
-            style={{ zIndex: 2002 }}
-          >
-            <span className="w-7 h-7 flex items-center justify-center"><LayersIcon /></span>
-          </button>
-          
-          {/* Lock map on GPS-knapp - kun når GPS er aktiv */}
-          {isLiveMode && (
-            <button
-              onClick={() => setIsMapLocked(!isMapLocked)}
-              className={`w-12 h-12 rounded-full shadow-lg transition-colors flex items-center justify-center ${
-                isMapLocked 
-                  ? 'bg-blue-600 hover:bg-blue-700 text-white' 
-                  : 'bg-gray-600 hover:bg-gray-700 text-white'
-              }`}
-              title={isMapLocked ? 'Map locked to GPS' : 'Lock map to GPS'}
-            >
-              {isMapLocked ? '🔒' : '🔓'}
-            </button>
-          )}
-          {/* Kompass start-knapp */}
-          {isLiveMode && !compass.isActive && (
+          {/* Kompass-knapp - alltid synlig */}
+          {!compass.isActive ? (
             <button
               onClick={async () => {
                 try {
@@ -3494,9 +3480,7 @@ export default function MapComponent({
             >
               🧭
             </button>
-          )}
-          {/* Kompass status-knapp */}
-          {isLiveMode && compass.isActive && (
+          ) : (
             <button
               onClick={() => {
                 alert(`Kompass status:\nCurrent (smoothed): ${compass.currentHeading?.toFixed(1) || 'N/A'}°\nRaw: ${compass.rawHeading?.toFixed(1) || 'N/A'}°\nLast valid: ${compass.lastValidHeading?.toFixed(1) || 'N/A'}°\nAktiv: ${compass.isActive}\nPermission: ${compass.permissionState}\nSupported: ${compass.isSupported ? 'Ja' : 'Nei'}${compass.error ? '\nError: ' + compass.error : ''}`);
@@ -3505,6 +3489,21 @@ export default function MapComponent({
               title="Kompass status"
             >
               🧭
+            </button>
+          )}
+          
+          {/* Lock map on GPS-knapp - kun når GPS er aktiv */}
+          {isLiveMode && (
+            <button
+              onClick={() => setIsMapLocked(!isMapLocked)}
+              className={`w-12 h-12 rounded-full shadow-lg transition-colors flex items-center justify-center ${
+                isMapLocked 
+                  ? 'bg-blue-600 hover:bg-blue-700 text-white' 
+                  : 'bg-gray-600 hover:bg-gray-700 text-white'
+              }`}
+              title={isMapLocked ? 'Map locked to GPS' : 'Lock map to GPS'}
+            >
+              {isMapLocked ? '🔒' : '🔓'}
             </button>
           )}
         </div>

--- a/src/components/mapcomponent.tsx
+++ b/src/components/mapcomponent.tsx
@@ -879,9 +879,12 @@ export default function MapComponent({
         heading,
       }));
     },
-    smoothingAlpha: 0.25, // EMA smoothing factor
-    stallMs: 700, // Faster stall detection
-    watchdogPeriodMs: 250, // Check more frequently
+    smoothingAlpha: 0.22,      // Tuned: smooth needle, not sluggish (default 0.22)
+    stallMs: 650,              // Faster stall detection (default 650)
+    watchdogPeriodMs: 220,     // Check frequently for recovery (default 220)
+    minRenderIntervalMs: 50,   // Max ~20 fps UI update (default 50)
+    minDeltaDeg: 0.8,          // Deadband: ignore tiny changes (default 0.8)
+    enableTiltGuard: true,     // Drop readings at extreme tilt >75° (default true)
     onStall: () => {
       console.warn('[MapComponent] Compass stall detected - auto-recovery in progress');
     },

--- a/src/components/mapcomponent.tsx
+++ b/src/components/mapcomponent.tsx
@@ -3453,13 +3453,18 @@ export default function MapComponent({
           
           {/* Live-posisjon-knapp */}
           <button
-            onClick={() => onLiveModeChange?.(!isLiveMode)}
+            onClick={() => {
+              const newLiveMode = !isLiveMode;
+              onLiveModeChange?.(newLiveMode);
+              // Auto-lock map when GPS is enabled, unlock when disabled
+              setIsMapLocked(newLiveMode);
+            }}
             className={`w-12 h-12 rounded-full shadow-lg transition-colors flex items-center justify-center ${
               isLiveMode 
                 ? 'bg-green-600 hover:bg-green-700 text-white' 
                 : 'bg-gray-600 hover:bg-gray-700 text-white'
             }`}
-            title={isLiveMode ? 'Live GPS ON' : 'Live GPS'}
+            title={isLiveMode ? 'Live GPS ON (locked)' : 'Live GPS'}
           >
             🛰️
           </button>
@@ -3489,21 +3494,6 @@ export default function MapComponent({
               title="Kompass status"
             >
               🧭
-            </button>
-          )}
-          
-          {/* Lock map on GPS-knapp - kun når GPS er aktiv */}
-          {isLiveMode && (
-            <button
-              onClick={() => setIsMapLocked(!isMapLocked)}
-              className={`w-12 h-12 rounded-full shadow-lg transition-colors flex items-center justify-center ${
-                isMapLocked 
-                  ? 'bg-blue-600 hover:bg-blue-700 text-white' 
-                  : 'bg-gray-600 hover:bg-gray-700 text-white'
-              }`}
-              title={isMapLocked ? 'Map locked to GPS' : 'Lock map to GPS'}
-            >
-              {isMapLocked ? '🔒' : '🔓'}
             </button>
           )}
         </div>

--- a/src/components/mapcomponent.tsx
+++ b/src/components/mapcomponent.tsx
@@ -3441,13 +3441,36 @@ export default function MapComponent({
             </>
           )}
 
+          {/* Layer-knapp */}
+          <button
+            className="w-12 h-12 rounded-full shadow-lg transition-colors flex items-center justify-center bg-white/90 border border-gray-300 hover:bg-gray-100"
+            onClick={() => setLayerIdx((layerIdx + 1) % LAYER_CONFIGS.length)}
+            title={`Bytt kartlag (${LAYER_CONFIGS[layerIdx].name})`}
+            style={{ zIndex: 2002 }}
+          >
+            <span className="w-7 h-7 flex items-center justify-center"><LayersIcon /></span>
+          </button>
+          
+          {/* Live-posisjon-knapp */}
+          <button
+            onClick={() => onLiveModeChange?.(!isLiveMode)}
+            className={`w-12 h-12 rounded-full shadow-lg transition-colors flex items-center justify-center ${
+              isLiveMode 
+                ? 'bg-green-600 hover:bg-green-700 text-white' 
+                : 'bg-gray-600 hover:bg-gray-700 text-white'
+            }`}
+            title={isLiveMode ? 'Live GPS ON' : 'Live GPS'}
+          >
+            🛰️
+          </button>
+          
           {/* Kompass-knapp - alltid synlig */}
           {!compass.isActive ? (
             <button
               onClick={async () => {
                 try {
                   await compass.startCompass();
-                  alert('Kompass startet!');
+                  // No alert - visual feedback from button color change is enough
                 } catch (error) {
                   alert((error as Error).message);
                 }
@@ -3468,29 +3491,6 @@ export default function MapComponent({
               🧭
             </button>
           )}
-          
-          {/* Live-posisjon-knapp */}
-          <button
-            onClick={() => onLiveModeChange?.(!isLiveMode)}
-            className={`w-12 h-12 rounded-full shadow-lg transition-colors flex items-center justify-center ${
-              isLiveMode 
-                ? 'bg-green-600 hover:bg-green-700 text-white' 
-                : 'bg-gray-600 hover:bg-gray-700 text-white'
-            }`}
-            title={isLiveMode ? 'Live GPS ON' : 'Live GPS'}
-          >
-            🛰️
-          </button>
-          
-          {/* Layer-knapp */}
-          <button
-            className="w-12 h-12 rounded-full shadow-lg transition-colors flex items-center justify-center bg-white/90 border border-gray-300 hover:bg-gray-100"
-            onClick={() => setLayerIdx((layerIdx + 1) % LAYER_CONFIGS.length)}
-            title={`Bytt kartlag (${LAYER_CONFIGS[layerIdx].name})`}
-            style={{ zIndex: 2002 }}
-          >
-            <span className="w-7 h-7 flex items-center justify-center"><LayersIcon /></span>
-          </button>
           
           {/* Lock map on GPS-knapp - kun når GPS er aktiv */}
           {isLiveMode && (

--- a/src/components/mapcomponent.tsx
+++ b/src/components/mapcomponent.tsx
@@ -3441,15 +3441,6 @@ export default function MapComponent({
             </>
           )}
 
-          {/* Layer-knapp */}
-          <button
-            className="w-12 h-12 rounded-full shadow-lg transition-colors flex items-center justify-center bg-white/90 border border-gray-300 hover:bg-gray-100"
-            onClick={() => setLayerIdx((layerIdx + 1) % LAYER_CONFIGS.length)}
-            title={`Bytt kartlag (${LAYER_CONFIGS[layerIdx].name})`}
-            style={{ zIndex: 2002 }}
-          >
-            <span className="w-7 h-7 flex items-center justify-center"><LayersIcon /></span>
-          </button>
           {/* Live-posisjon-knapp */}
           <button
             onClick={() => onLiveModeChange?.(!isLiveMode)}
@@ -3461,6 +3452,16 @@ export default function MapComponent({
             title={isLiveMode ? 'Live GPS ON' : 'Live GPS'}
           >
             🛰️
+          </button>
+          
+          {/* Layer-knapp */}
+          <button
+            className="w-12 h-12 rounded-full shadow-lg transition-colors flex items-center justify-center bg-white/90 border border-gray-300 hover:bg-gray-100"
+            onClick={() => setLayerIdx((layerIdx + 1) % LAYER_CONFIGS.length)}
+            title={`Bytt kartlag (${LAYER_CONFIGS[layerIdx].name})`}
+            style={{ zIndex: 2002 }}
+          >
+            <span className="w-7 h-7 flex items-center justify-center"><LayersIcon /></span>
           </button>
           
           {/* Lock map on GPS-knapp - kun når GPS er aktiv */}

--- a/src/components/mapcomponent.tsx
+++ b/src/components/mapcomponent.tsx
@@ -82,6 +82,7 @@ interface MapComponentProps {
   onHuntingAreaDefined?: (area: HuntingArea) => void;
   onCancelHuntingAreaDefinition?: () => void;
   onRefreshHuntingAreas?: () => void;
+  onRegisterSync?: (syncFn: () => void) => void;
 }
 
 interface CategoryFilter {
@@ -704,6 +705,7 @@ export default function MapComponent({
   onHuntingAreaDefined,
   onCancelHuntingAreaDefinition,
   onRefreshHuntingAreas,
+  onRegisterSync,
   activeTeam = null,
 }: MapComponentProps) {
   const [showTargetDialog, setShowTargetDialog] = useState(false);
@@ -1487,6 +1489,13 @@ export default function MapComponent({
       }
     }
   };
+
+  // Register sync function with parent component
+  useEffect(() => {
+    if (onRegisterSync) {
+      onRegisterSync(handleSyncData);
+    }
+  }, [onRegisterSync]);
 
   // Håndter lagring av spor fra dialog
   const handleSaveTrackFromDialog = () => {
@@ -3311,16 +3320,6 @@ export default function MapComponent({
                         {/* Start/Stopp spor knapp kun i søk-modus */}
         {mode === 'søk' && (
           <div className="fixed bottom-4 inset-x-0 z-[2001] flex flex-wrap justify-center items-center gap-2 px-2 -ml-[15px]" style={{ pointerEvents: 'none' }}>
-            {/* Synkroniser knapp */}
-          <button
-              onClick={handleSyncData}
-              className="w-12 h-12 rounded-full shadow-lg font-semibold text-[0.75rem] transition-colors border flex items-center justify-center bg-blue-600 hover:bg-blue-700 text-white border-blue-700"
-              title="Synkroniser alle data med teamet"
-              style={{ pointerEvents: 'auto' }}
-            >
-                      🔄
-          </button>
-
                     {/* Obs-knapp */}
           <button
                       onClick={toggleObservationMode}

--- a/src/components/mapcomponent.tsx
+++ b/src/components/mapcomponent.tsx
@@ -3431,13 +3431,13 @@ export default function MapComponent({
           </button>
               
               {/* Pil høyre - neste treffpunkt */}
-              <button
+          <button
                 onClick={onNextTarget}
                 className="w-12 h-12 rounded-full shadow-lg transition-colors flex items-center justify-center bg-blue-600 hover:bg-blue-700 text-white"
                 title="Neste treffpunkt"
               >
                 →
-              </button>
+          </button>
             </>
           )}
 

--- a/src/components/msr-retikkel.tsx
+++ b/src/components/msr-retikkel.tsx
@@ -8,10 +8,11 @@ interface MSRRetikkelProps {
   opacity: number;
   style: 'msr' | 'ivar';
   verticalPosition?: number; // 0-100, kun for ivar-style
-  currentPosition?: { lat: number; lng: number };
+  currentPosition?: { lat: number; lng: number; heading?: number };
+  compassMode?: 'off' | 'arrow' | 'map';
 }
 
-export default function MSRRetikkel({ isVisible, opacity, style, verticalPosition = 50, currentPosition }: MSRRetikkelProps) {
+export default function MSRRetikkel({ isVisible, opacity, style, verticalPosition = 50, currentPosition, compassMode = 'off' }: MSRRetikkelProps) {
   const map = useMap();
   const [scaleValues, setScaleValues] = useState({ x: 0, y: 0 });
   const [screenSize, setScreenSize] = useState({ width: 0, height: 0 });

--- a/src/components/settingsmenu.tsx
+++ b/src/components/settingsmenu.tsx
@@ -65,6 +65,8 @@ interface SettingsMenuProps {
   onHuntingBoundaryColorChange?: (color: string) => void;
   onHuntingBoundaryWeightChange?: (weight: number) => void;
   onHuntingBoundaryOpacityChange?: (opacity: number) => void;
+  compassSliceLength?: number; // 0-100 (% of screen height)
+  onCompassSliceLengthChange?: (length: number) => void;
 }
 
 export interface HuntingArea {
@@ -124,7 +126,9 @@ export default function SettingsMenu({
   huntingBoundaryOpacity,
   onHuntingBoundaryColorChange,
   onHuntingBoundaryWeightChange,
-  onHuntingBoundaryOpacityChange
+  onHuntingBoundaryOpacityChange,
+  compassSliceLength,
+  onCompassSliceLengthChange
 }: SettingsMenuProps & { currentCenter?: { lat: number, lng: number } }) {
   const menuRef = useRef<HTMLDivElement>(null);
   const [showHomeSaved, setShowHomeSaved] = useState(false);
@@ -133,6 +137,7 @@ export default function SettingsMenu({
   const [isHomeExpanded, setIsHomeExpanded] = useState(false);
   const [isPieSliceExpanded, setIsPieSliceExpanded] = useState(false);
   const [isReticleExpanded, setIsReticleExpanded] = useState(false);
+  const [isCompassExpanded, setIsCompassExpanded] = useState(false);
   const [isFilterExpanded, setIsFilterExpanded] = useState(false);
   const [isShootTrackExpanded, setIsShootTrackExpanded] = useState(false);
   const [isHuntingAreaExpanded, setIsHuntingAreaExpanded] = useState(false);
@@ -368,6 +373,46 @@ export default function SettingsMenu({
                   </div>
                 </div>
               )}
+            </div>
+          )}
+        </div>
+      )}
+      
+      {/* Compass Settings Expander */}
+      {compassSliceLength !== undefined && onCompassSliceLengthChange && (
+        <div className="mb-4 border border-gray-200 rounded-lg overflow-hidden">
+          <button
+            type="button"
+            onClick={() => setIsCompassExpanded(!isCompassExpanded)}
+            className="w-full flex items-center justify-between px-3 py-2 bg-gray-50 hover:bg-gray-100 transition-colors"
+          >
+            <span className="text-sm font-medium text-gray-700">Compass settings</span>
+            <span className="text-gray-500 text-sm">{isCompassExpanded ? '▼' : '▶'}</span>
+          </button>
+          
+          {isCompassExpanded && (
+            <div className="p-3 bg-white">
+              {/* Compass Slice Length */}
+              <div className="mb-3">
+                <label className="text-xs font-medium text-gray-700 block mb-1">
+                  Indikatorlengde: {compassSliceLength}%
+                </label>
+                <input
+                  type="range"
+                  min="10"
+                  max="50"
+                  step="5"
+                  value={compassSliceLength}
+                  onChange={(e) => onCompassSliceLengthChange(Number(e.target.value))}
+                  className="w-full h-1.5 bg-gray-200 rounded-full appearance-none cursor-pointer hover:bg-gray-300 transition-colors"
+                  style={{
+                    background: `linear-gradient(to right, #3b82f6 0%, #3b82f6 ${(compassSliceLength - 10) / 40 * 100}%, #e5e7eb ${(compassSliceLength - 10) / 40 * 100}%, #e5e7eb 100%)`
+                  }}
+                />
+                <div className="text-xs text-gray-500 mt-1">
+                  Prosent av skjermhøyde
+                </div>
+              </div>
             </div>
           )}
         </div>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds compass on/off + lock controls with a configurable on-map indicator and optional map rotation, wires settings through the app, introduces a filter-triggered sync, and revamps the compass hook.
> 
> - **Map/UI**:
>   - Add compass toggle and lock controls (toolbar + top-right lock button) with a red `CompassSlice` indicator and optional `MapRotator` for map rotation.
>   - Wire compass state via `page.tsx → awaremap.tsx → mapcomponent.tsx` (`compassMode`, `isCompassLocked`, `compassSliceLength`).
>   - Tweak live GPS button to auto-lock map when enabled; minor UI fixes in measurement panel and buttons.
> - **Compass**:
>   - Integrate enhanced `useCompass` hook with smoothing, stall recovery, deadband, tilt-guard, and throttled rendering.
>   - Extend `MSRRetikkel` to accept `heading` and optional `compassMode`.
> - **Settings**:
>   - Add Compass settings expander to `SettingsMenu` with slider for `compassSliceLength`.
> - **Sync**:
>   - Expose sync via `onRegisterSync` from map; add "Synkroniser" button in `FilterMenu` (søk mode) to trigger it.
> - **Docs**:
>   - Add `REFACTORING_NOTES.md` outlining proposed refactors (props consolidation, pixel↔meter utils, compass state unification, data layer, etc.).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 904bd61e8e4c3462f33c8e3603421b49571da1ab. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->