### PR TITLE
Compass buttons and workflow

### DIFF
--- a/src/components/mapcomponent.tsx
+++ b/src/components/mapcomponent.tsx
@@ -916,8 +916,8 @@ export default function MapComponent({
       }));
     },
     smoothingAlpha: 0.22,      // Tuned: smooth needle, not sluggish (default 0.22)
-    stallMs: 650,              // Faster stall detection (default 650)
-    watchdogPeriodMs: 220,     // Check frequently for recovery (default 220)
+    stallMs: 600,              // Faster stall detection (default 600)
+    watchdogPeriodMs: 200,     // Check frequently for recovery (default 200)
     minRenderIntervalMs: 50,   // Max ~20 fps UI update (default 50)
     minDeltaDeg: 0.8,          // Deadband: ignore tiny changes (default 0.8)
     enableTiltGuard: true,     // Drop readings at extreme tilt >75° (default true)
@@ -925,6 +925,16 @@ export default function MapComponent({
       console.warn('[MapComponent] Compass stall detected - auto-recovery in progress');
     },
   });
+  
+  // Auto-sync compassMode when compass stops (e.g., permissions lost)
+  useEffect(() => {
+    if (!compass.isActive && compassMode === 'on') {
+      // Compass stopped unexpectedly (permissions lost) - update UI
+      console.warn('[MapComponent] Compass stopped - resetting UI state');
+      onCompassModeChange?.('off');
+      onCompassLockedChange?.(false);
+    }
+  }, [compass.isActive, compassMode, onCompassModeChange, onCompassLockedChange]);
   
   // Tracking state for søk-modus
   const [savedTracks, setSavedTracks] = useState<SavedTrack[]>([]);

--- a/src/hooks/useCompass.ts
+++ b/src/hooks/useCompass.ts
@@ -1,5 +1,5 @@
-// useCompass.ts
-// Smooth, resilient compass hook for iOS/Android web (Next/Vercel friendly)
+// useCompass.ts — resilient compass (startup handshake + first-event watchdog)
+// Paste this whole file. API: startCompass/stopCompass + currentHeading etc.
 
 import { useState, useCallback, useEffect, useRef } from 'react';
 
@@ -7,34 +7,40 @@ export interface UseCompassOptions {
   isEnabled: boolean;
   onHeadingChange?: (heading: number) => void;
 
-  // Smoothing (EMA)
-  smoothingAlpha?: number;        // default 0.22 (0..1, lavere = roligere)
+  // Smoothing
+  smoothingAlpha?: number;        // default 0.22
 
-  // Stall/recovery
-  stallMs?: number;               // default 650 ms: hvor lenge uten events før vi antar stall
-  watchdogPeriodMs?: number;      // default 220 ms: hvor ofte vi sjekker for stall
-  onStall?: () => void;           // valgfri callback når stall oppdages
+  // Recovery (runtime stall)
+  stallMs?: number;               // default 600 ms
+  watchdogPeriodMs?: number;      // default 200 ms
+  onStall?: () => void;
 
-  // Tegnehastighet/ro
-  minRenderIntervalMs?: number;   // default 50 ms: maks ~20 fps for UI-oppdatering
-  minDeltaDeg?: number;           // default 0.8°: deadband – ignorer små endringer
-  enableTiltGuard?: boolean;      // default true: dropp målinger ved ekstrem tilt
+  // Startup reliability
+  firstEventDeadlineMs?: number;  // default 1200 ms (time to wait for first event)
+  startRetryDelayMs?: number;     // default 80 ms (small delay between re-attaches)
+  startTimeoutMs?: number;        // default 6000 ms (overall startup guard)
+
+  // Render pacing
+  minRenderIntervalMs?: number;   // default 50 ms (~20 fps)
+  minDeltaDeg?: number;           // default 0.8°
+  enableTiltGuard?: boolean;      // default true
 }
 
 export interface UseCompassReturn {
-  // Tilstand
+  // State
   isActive: boolean;
   isSupported: boolean;
   permissionState: 'unknown' | 'granted' | 'denied' | 'not-required';
+  phase: 'idle' | 'requesting-permission' | 'starting' | 'running' | 'stalled';
   error?: string;
 
-  // Verdier
-  currentHeading: number | null;  // smoothed [0..360)
-  rawHeading: number | null;      // siste rå vinkel [0..360)
+  // Values
+  currentHeading: number | null;  // smoothed
+  rawHeading: number | null;      // last raw
   lastValidHeading: number | null;
 
-  // Kontroll
-  startCompass: () => Promise<void>;  // kall i bruker-gest (onClick)
+  // Control
+  startCompass: () => Promise<void>; // call from a user gesture (tap)
   stopCompass: () => void;
 }
 
@@ -44,19 +50,11 @@ function normalizeDeg(x: number): number {
   if (d < 0) d += 360;
   return d;
 }
-
 function wrapDiff(a: number, b: number): number {
-  let d = a - b;
-  if (d > 180) d -= 360;
-  if (d < -180) d += 360;
-  return d;
+  let d = a - b; if (d > 180) d -= 360; if (d < -180) d += 360; return d;
 }
+function angAbsDiff(a: number, b: number): number { return Math.abs(wrapDiff(a, b)); }
 
-function angAbsDiff(a: number, b: number): number {
-  return Math.abs(wrapDiff(a, b));
-}
-
-// EMA smoothing som tar hensyn til 0/360-wrap
 function makeSmoother(alpha = 0.22) {
   let prev: number | null = null;
   return (v: number) => {
@@ -72,29 +70,33 @@ export function useCompass({
   isEnabled,
   onHeadingChange,
 
-  // Defaults tunet for “smud” nål og rask recovery
   smoothingAlpha = 0.22,
-  stallMs = 650,
-  watchdogPeriodMs = 220,
+
+  stallMs = 600,
+  watchdogPeriodMs = 200,
   onStall,
+
+  firstEventDeadlineMs = 1200,
+  startRetryDelayMs = 80,
+  startTimeoutMs = 6000,
 
   minRenderIntervalMs = 50,
   minDeltaDeg = 0.8,
   enableTiltGuard = true,
 }: UseCompassOptions): UseCompassReturn {
-  // Offentlig state
   const [isActive, setIsActive] = useState(false);
   const [currentHeading, setCurrentHeading] = useState<number | null>(null);
   const [rawHeading, setRawHeading] = useState<number | null>(null);
   const [lastValidHeading, setLastValidHeading] = useState<number | null>(null);
   const [permissionState, setPermissionState] =
     useState<'unknown' | 'granted' | 'denied' | 'not-required'>('unknown');
+  const [phase, setPhase] = useState<'idle' | 'requesting-permission' | 'starting' | 'running' | 'stalled'>('idle');
   const [error, setError] = useState<string | undefined>(undefined);
 
   const isSupported =
     typeof window !== 'undefined' && 'DeviceOrientationEvent' in window;
 
-  // Interne refs
+  // Internals
   const smootherRef = useRef(makeSmoother(smoothingAlpha));
   const lastEventTsRef = useRef<number>(0);
   const lastRawRef = useRef<number | null>(null);
@@ -107,28 +109,28 @@ export function useCompass({
   const lastRenderTsRef = useRef(0);
   const lastSentHeadingRef = useRef<number | null>(null);
 
-  // Oppdater smoother hvis alpha endres
-  useEffect(() => {
-    smootherRef.current = makeSmoother(smoothingAlpha);
-  }, [smoothingAlpha]);
+  const startLockRef = useRef(false);            // single-flight start
+  const startBeginTsRef = useRef<number>(0);     // guard against endless start
+  const firstEventSeenRef = useRef(false);       // startup handshake
 
-  // Heading fra event (bruk iOS webkitCompassHeading om tilgjengelig)
+  // Update smoother if alpha changes
+  useEffect(() => { smootherRef.current = makeSmoother(smoothingAlpha); }, [smoothingAlpha]);
+
+  // Compute heading
   const computeHeading = useCallback((evt: DeviceOrientationEvent): number | null => {
     const anyEvt: any = evt as any;
 
-    // Tilt guard (ved ekstrem tilt gir mange enheter dårlig heading)
     if (enableTiltGuard) {
       const { beta, gamma } = evt;
       if (typeof beta === 'number' && typeof gamma === 'number') {
         const absTilt = Math.max(Math.abs(beta), Math.abs(gamma));
-        if (absTilt > 75) return null; // dropp oppdatering
+        if (absTilt > 75) return null; // drop extreme tilt
       }
     }
 
     if (typeof anyEvt.webkitCompassHeading === 'number' && !isNaN(anyEvt.webkitCompassHeading)) {
       return normalizeDeg(anyEvt.webkitCompassHeading);
     }
-
     if (typeof evt.alpha === 'number' && evt.alpha != null) {
       const ang =
         (window.screen.orientation && typeof window.screen.orientation.angle === 'number')
@@ -139,7 +141,7 @@ export function useCompass({
     return null;
   }, [enableTiltGuard]);
 
-  // Lytter
+  // Attach/remove listener
   const attachListener = useCallback(() => {
     if (activeRef.current) return;
 
@@ -148,6 +150,7 @@ export function useCompass({
       if (raw == null || Number.isNaN(raw)) return;
       lastRawRef.current = raw;
       lastEventTsRef.current = performance.now();
+      if (!firstEventSeenRef.current) firstEventSeenRef.current = true;
     };
 
     window.addEventListener('deviceorientation', onOrientation, { passive: true } as AddEventListenerOptions);
@@ -164,124 +167,162 @@ export function useCompass({
     removeOrientationRef.current = null;
   }, []);
 
-  // Start
+  // rAF drawing loop
+  const ensureRAF = useCallback(() => {
+    if (rafRef.current != null) return;
+
+    const tick = () => {
+      const now = performance.now();
+      const raw = lastRawRef.current;
+
+      if (raw != null && now - lastRenderTsRef.current >= minRenderIntervalMs) {
+        const smooth = smootherRef.current(raw);
+        const lastSent = lastSentHeadingRef.current;
+
+        if (lastSent == null || angAbsDiff(smooth, lastSent) >= minDeltaDeg) {
+          setRawHeading(raw);
+          setCurrentHeading(smooth);
+          setLastValidHeading(smooth);
+          onHeadingChange?.(smooth);
+
+          lastSentHeadingRef.current = smooth;
+          lastRenderTsRef.current = now;
+        }
+      }
+      rafRef.current = requestAnimationFrame(tick);
+    };
+    rafRef.current = requestAnimationFrame(tick);
+  }, [minRenderIntervalMs, minDeltaDeg, onHeadingChange]);
+
+  // Runtime watchdog (stall)
+  const ensureWatchdog = useCallback(() => {
+    if (watchdogRef.current != null) return;
+
+    watchdogRef.current = window.setInterval(() => {
+      if (document.visibilityState === 'hidden' || !isActive) return;
+      const idle = performance.now() - (lastEventTsRef.current || 0);
+      if (idle > stallMs) {
+        setPhase('stalled');
+        onStall?.();
+        // soft kick
+        detachListener();
+        smootherRef.current = makeSmoother(smoothingAlpha);
+        attachListener();
+
+        // hard kick if still dead
+        setTimeout(() => {
+          const stillIdle = performance.now() - (lastEventTsRef.current || 0);
+          if (stillIdle > stallMs * 1.25) {
+            detachListener();
+            smootherRef.current = makeSmoother(smoothingAlpha);
+            setTimeout(attachListener, 0);
+          }
+        }, Math.min(120, stallMs * 0.2));
+      } else if (phase !== 'running' && isActive) {
+        setPhase('running');
+      }
+    }, watchdogPeriodMs);
+  }, [attachListener, detachListener, isActive, onStall, phase, smoothingAlpha, stallMs, watchdogPeriodMs]);
+
+  // Start (call from user gesture)
   const startCompass = useCallback(async () => {
     if (!isSupported) {
       const msg = 'DeviceOrientation ikke støttet';
       setError(msg);
       setPermissionState('denied');
+      setPhase('idle');
       throw new Error(msg);
     }
+    if (startLockRef.current) return; // prevent concurrent starts
+    startLockRef.current = true;
 
-    // Må kalles fra bruker-gest i iOS
     try {
+      setPhase('requesting-permission');
       const D: any = DeviceOrientationEvent;
       if (typeof D?.requestPermission === 'function') {
         const res = await D.requestPermission();
         if (res !== 'granted') {
           setPermissionState('denied');
           setError('Permission not granted');
+          setPhase('idle');
           throw new Error('Permission not granted');
         }
         setPermissionState('granted');
       } else {
         setPermissionState('not-required');
       }
-    } catch (e: any) {
-      setPermissionState('denied');
-      setError(e?.message || 'Permission error');
-      throw e;
-    }
 
-    setError(undefined);
-    setIsActive(true);
+      // Begin startup sequence
+      setError(undefined);
+      setIsActive(true);
+      setPhase('starting');
 
-    // Koble på sensoren
-    attachListener();
+      // Prepare for handshake
+      firstEventSeenRef.current = false;
+      lastEventTsRef.current = 0;
+      lastRawRef.current = null;
+      smootherRef.current = makeSmoother(smoothingAlpha);
 
-    // rAF-tegneloop med throttling + deadband
-    if (rafRef.current == null) {
-      const tick = () => {
-        const now = performance.now();
-        const raw = lastRawRef.current;
+      // Attach + RAF + watchdog
+      attachListener();
+      ensureRAF();
+      ensureWatchdog();
 
-        if (raw != null && now - lastRenderTsRef.current >= minRenderIntervalMs) {
-          const smooth = smootherRef.current(raw);
-          const lastSent = lastSentHeadingRef.current;
+      // Wait for first event with deadline; retry attach if needed
+      startBeginTsRef.current = performance.now();
 
-          if (lastSent == null || angAbsDiff(smooth, lastSent) >= minDeltaDeg) {
-            setRawHeading(raw);
-            setCurrentHeading(smooth);
-            setLastValidHeading(smooth);
-            onHeadingChange?.(smooth);
-
-            lastSentHeadingRef.current = smooth;
-            lastRenderTsRef.current = now;
+      const tryUntil = async (deadlineMs: number) => {
+        while (performance.now() - startBeginTsRef.current < deadlineMs) {
+          if (firstEventSeenRef.current) {
+            setPhase('running');
+            return true;
+          }
+          await new Promise(r => setTimeout(r, startRetryDelayMs));
+          if (!firstEventSeenRef.current) { // kick the stream if still no event
+            detachListener();
+            attachListener();
           }
         }
-        rafRef.current = requestAnimationFrame(tick);
+        return false;
       };
-      rafRef.current = requestAnimationFrame(tick);
-    }
 
-    // Watchdog: re-attach ved stall, pause når skjult
-    if (watchdogRef.current == null) {
-      watchdogRef.current = window.setInterval(() => {
-        if (document.visibilityState === 'hidden') return;
-        const idle = performance.now() - (lastEventTsRef.current || 0);
-        if (idle > stallMs) {
-          onStall?.();
-          // Soft kick
-          detachListener();
-          smootherRef.current = makeSmoother(smoothingAlpha);
-          attachListener();
-
-          // Hard kick hvis fortsatt dødt
-          setTimeout(() => {
-            const stillIdle = performance.now() - (lastEventTsRef.current || 0);
-            if (stillIdle > stallMs * 1.25) {
-              detachListener();
-              smootherRef.current = makeSmoother(smoothingAlpha);
-              setTimeout(attachListener, 0);
-            }
-          }, Math.min(120, stallMs * 0.2));
+      const gotFirst = await tryUntil(firstEventDeadlineMs);
+      if (!gotFirst) {
+        // As a last attempt, give it a slightly longer window before failing:
+        const gotAfter = await tryUntil(startTimeoutMs);
+        if (!gotAfter) {
+          setError('Ingen kompassdata mottatt ved oppstart');
+          setPhase('idle');
+          throw new Error('No sensor events on start');
         }
-      }, watchdogPeriodMs);
+      }
+      // success → phase set to 'running' by watchdog or above
+    } finally {
+      startLockRef.current = false;
     }
-  }, [
-    isSupported,
-    attachListener,
-    detachListener,
-    onHeadingChange,
-    stallMs,
-    watchdogPeriodMs,
-    onStall,
-    smoothingAlpha,
-    minRenderIntervalMs,
-    minDeltaDeg,
-  ]);
+  }, [attachListener, detachListener, ensureRAF, ensureWatchdog, isSupported, smoothingAlpha, startRetryDelayMs, firstEventDeadlineMs, startTimeoutMs]);
 
   // Stop
   const stopCompass = useCallback(() => {
     setIsActive(false);
+    setPhase('idle');
     detachListener();
     if (rafRef.current != null) { cancelAnimationFrame(rafRef.current); rafRef.current = null; }
     if (watchdogRef.current != null) { clearInterval(watchdogRef.current); watchdogRef.current = null; }
-    setCurrentHeading(null);
-    setRawHeading(null);
-    // bevar lastValidHeading
+    // keep lastValidHeading
   }, [detachListener]);
 
-  // Lifecycle
+  // Lifecycle (visibility/pageshow)
   useEffect(() => {
     if (!isEnabled) {
       if (isActive) stopCompass();
       return;
     }
     const onVisibility = () => {
-      if (document.visibilityState === 'visible' && isActive) {
+      if (!isActive) return;
+      if (document.visibilityState === 'visible') {
         attachListener();
-      } else if (document.visibilityState === 'hidden') {
+      } else {
         detachListener();
       }
     };
@@ -289,23 +330,20 @@ export function useCompass({
 
     document.addEventListener('visibilitychange', onVisibility);
     window.addEventListener('pageshow', onPageShow);
-
     return () => {
       document.removeEventListener('visibilitychange', onVisibility);
       window.removeEventListener('pageshow', onPageShow);
     };
   }, [isEnabled, isActive, attachListener, detachListener, stopCompass]);
 
-  // Gesture-kick med cooldown (vekker stream raskt ved berøring)
+  // Gesture kick with cooldown (wake quickly on touch if stalled)
   useEffect(() => {
     if (!isActive) return;
-
     let lastKick = 0;
-    const kickCooldownMs = 300;
-
+    const cooldown = 300;
     const poke = () => {
       const now = performance.now();
-      if (now - lastKick < kickCooldownMs) return;
+      if (now - lastKick < cooldown) return;
       const idle = now - (lastEventTsRef.current || 0);
       if (idle > stallMs) {
         lastKick = now;
@@ -313,7 +351,6 @@ export function useCompass({
         attachListener();
       }
     };
-
     window.addEventListener('pointerdown', poke, { passive: true } as AddEventListenerOptions);
     return () => window.removeEventListener('pointerdown', poke as any);
   }, [isActive, stallMs, attachListener, detachListener]);
@@ -322,6 +359,7 @@ export function useCompass({
     isActive,
     isSupported,
     permissionState,
+    phase,
     error,
     currentHeading,
     rawHeading,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Refactors the compass hook with a startup handshake + watchdog and adds an rAF-based, deadbanded map rotation, plus minor tuning and UI sync when compass stops.
> 
> - **Compass**:
>   - **Hook rewrite (`src/hooks/useCompass.ts`)**:
>     - Adds startup handshake, first-event watchdog, `phase` state, and single-flight start.
>     - Introduces options: `firstEventDeadlineMs`, `startRetryDelayMs`, `startTimeoutMs`.
>     - Implements rAF render loop and interval watchdog for stall detection/recovery; improves visibility/pageshow handling and gesture kick.
>     - Tweaks defaults (`stallMs` 600, `watchdogPeriodMs` 200); preserves last valid heading on stop.
> - **Map/UI**:
>   - **Map rotation (`MapRotator` in `src/components/mapcomponent.tsx`)**: switches to requestAnimationFrame loop with heading refs and 0.5° deadband; proper cleanup/reset when disabled.
>   - **Compass usage**: updates options to new defaults and adds effect to auto-toggle `compassMode` off and unlock UI if compass stops.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3acd8e513e88df55e5251b3b37ab92d9de0a58bf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->